### PR TITLE
Avoid zombie child processes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Install dependencies
+      run: |
+          sudo apt update
+          sudo apt install libxinerama-dev
     - name: Build
       run: cargo build --release
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ lazy_static = "1.3.0"
 bitflags = "1.1.0"
 x11 = {version = "*", features = ["xlib", "xinerama"]}
 x11-dl = "2.18.3"
-
+nix = "0.15"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use std::rc::Rc;
 use std::process::Command;
 use std::thread;
 use std::sync::mpsc;
+use nix::sys::signal::{self, SigHandler, Signal};
 
 use crate::config::*;
 
@@ -23,6 +24,8 @@ fn main() {
 
     let xlib = Rc::new(XlibWrapper::new());
     let window_manager = WindowManager::new(xlib.clone());
+    // Avoid zombies by ignoring SIGCHLD
+    unsafe { signal::signal(Signal::SIGCHLD, SigHandler::SigIgn) }.unwrap();
     call_commands(ExecTime::Pre);
     thread::spawn(move || {
         match rx.recv() {


### PR DESCRIPTION
Hadlock spawns children without taking care of `SIGCHLD`, which leads to
zombies. We can either `wait()`/`waitpid()` or let the kernel know that
we don't care by ignoring `SIGCHLD`.

The solution uses `nix::sys::signal` unconditionally, since Hadlock is
an X11 wm, and it's reasonable to assume a suitable `nix::sys`
environment.